### PR TITLE
Fixes the error that Matrix is not found

### DIFF
--- a/vignettes/technical_integration.Rmd
+++ b/vignettes/technical_integration.Rmd
@@ -10,7 +10,7 @@ vignette: >
   %\VignetteIndexEntry{Technical Integration - Using textAnnotatoR with Other R Tools}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
-  %\VignetteDepends{dplyr, ggplot2}
+  %\VignetteDepends{dplyr, ggplot2, quanteda}
 ---
 
 ```{r setup, include=FALSE}
@@ -111,7 +111,7 @@ This structure makes it readily compatible with standard R data manipulation too
 
 The [quanteda](https://quanteda.io/) package is a powerful framework for text analysis. Here's how you can combine textAnnotatoR annotations with quanteda:
 
-```{r eval=TRUE}
+```{r, eval = requireNamespace("quanteda", quietly = TRUE)}
 library(quanteda)
 library(quanteda.textstats)
 library(dplyr)


### PR DESCRIPTION
Occurs in R CMD CHECK when trying to load quanteda and not finding it. This ensures that the error won't occur.

The vignette `technical_integration.Rmd` is trying to load the **quanteda** package, which depends on the **Matrix** package, but **Matrix** is not available in the `R CMD CHECK` environment.

The error occurs during `R CMD CHECK` but not when knitting directly because when you knit directly, you're using your regular R environment where all packages are installed.  `R CMD CHECK` creates a clean, isolated environment and only installs the packages declared in the DESCRIPTION file.

The fix only runs the code where **quanteda** is used if the required packages are available.